### PR TITLE
Create 2025-04-20-Orlando Code Camp 2025.md

### DIFF
--- a/_posts/2025-04-20-Orlando Code Camp 2025.md
+++ b/_posts/2025-04-20-Orlando Code Camp 2025.md
@@ -1,0 +1,18 @@
+# 2025 Orlando Code Camp 
+
+This year I spoke about Xunit V3.   
+
+
+
+You can find the sample code and powerpoint in this repo.  
+
+In this demo I talked about 
+* Facts
+* Theory
+* Capturing Console.Writeline in tests
+* Orderers
+* Fixtures
+  
+
+https://github.com/Ken-Tucker/OrlandoCodeCamp_XunitV3
+

--- a/_posts/2025-04-20-Orlando Code Camp 2025.md
+++ b/_posts/2025-04-20-Orlando Code Camp 2025.md
@@ -4,7 +4,7 @@ This year I spoke about Xunit V3.
 
 
 
-You can find the sample code and powerpoint in this repo.  
+You can find the sample code and PowerPoint in this repo.  
 
 In this demo I talked about 
 * Facts

--- a/_posts/2025-04-20-Orlando Code Camp 2025.md
+++ b/_posts/2025-04-20-Orlando Code Camp 2025.md
@@ -9,8 +9,7 @@ You can find the sample code and PowerPoint in this repo.
 In this demo I talked about 
 * Facts
 * Theory
-* Capturing Console.Writeline in tests
-* Orderers
+* Capturing Console.WriteLine in tests
 * Fixtures
   
 


### PR DESCRIPTION
This pull request adds a new blog post about the 2025 Orlando Code Camp to the `_posts` directory. The post outlines the speaker's presentation on Xunit V3, including key topics covered and a link to the associated sample code and presentation materials.

Content added to the blog post:

* Title: "2025 Orlando Code Camp" with a brief description of the speaker's presentation on Xunit V3.
* Topics discussed in the presentation: Facts, Theory, Capturing `Console.Writeline` in tests, Orderers, and Fixtures.
* Link to the GitHub repository containing the sample code and PowerPoint slides for the presentation.